### PR TITLE
The .par file must be generated with only one paramater set in case of duplication

### DIFF
--- a/src/main/java/org/gridsuite/mapping/server/model/RuleEntity.java
+++ b/src/main/java/org/gridsuite/mapping/server/model/RuleEntity.java
@@ -71,8 +71,4 @@ public class RuleEntity extends AbstractManuallyAssignedIdentifierEntity<UUID> {
         this.filters = ruleToCopy.getFilters().stream().map(filterEntity -> new FilterEntity(newID, filterEntity)).collect(Collectors.toList());
 
     }
-
-    public String[] getInstantiatedModel() {
-        return new String[]{mappedModel, setGroup};
-    }
 }


### PR DESCRIPTION
When defining two automatons of the same type, i.e. same model, same group, then convert to .groovy, the .par file generated with two same set of parameters. For example, a mapping with two automatons with the same CLA => must generate only once CLA