### PR TITLE
Type of currentLimitAutomaton_OrderToEmit must be INT

### DIFF
--- a/src/main/resources/IEEE14Models.sql
+++ b/src/main/resources/IEEE14Models.sql
@@ -250,7 +250,7 @@ VALUES ('LoadPQ', 'load_P0Pu', 0, 'p_pu', 2),
        ('LoadPQ', 'load_UPhase0', 0, 'angle_pu', 2);
 
 INSERT INTO model_parameter_definitions (model_name, name, origin, origin_name, type)
-VALUES ('CurrentLimitAutomaton', 'currentLimitAutomaton_OrderToEmit', 2, NULL, 2),
+VALUES ('CurrentLimitAutomaton', 'currentLimitAutomaton_OrderToEmit', 2, NULL, 0),
        ('CurrentLimitAutomaton', 'currentLimitAutomaton_Running', 2, NULL, 1),
        ('CurrentLimitAutomaton', 'currentLimitAutomaton_IMax', 2, NULL, 2),
        ('CurrentLimitAutomaton', 'currentLimitAutomaton_tLagBeforeActing', 2, NULL, 2);


### PR DESCRIPTION
launching job 'Job'
DYN Error: invalid parameter type in request of currentLimitAutomaton_OrderToEmit (expected integer, got double, warning with string you need to explicitly cast the parameter given to newParameter) ( PARParameter.cpp:63 )
Dynawo execution failed

Test with dynawalt 1.11.0