### PR TITLE
Dynamic simulation - Default empty string value for custom variable ex-resources.automaton

### DIFF
--- a/src/main/java/org/gridsuite/mapping/server/service/implementation/ModelServiceImpl.java
+++ b/src/main/java/org/gridsuite/mapping/server/service/implementation/ModelServiceImpl.java
@@ -58,7 +58,7 @@ public class ModelServiceImpl implements ModelService {
     public static final String VARIABLES_SET_NOT_FOUND = "Variables set not found: ";
     public static final String SETS_GROUP_NOT_FOUND = "Sets group not found: ";
 
-    @Value("${ex-resources.automaton}")
+    @Value("${ex-resources.automaton:}")
     String exResourcesAutomaton;
 
     private final ResourcePatternResolver resourcePatternResolver;


### PR DESCRIPTION
Bug produced following to PR: https://github.com/gridsuite/dynamic-mapping-server/pull/68 

Exception at starting the dynamic-mapping-server on demo azure due to the lack of variable

2023-07-13 07:14:13.229  WARN 1 --- [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'modelController' defined in file [/app/classes/org/gridsuite/mapping/server/controller/ModelController.class]: Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'modelServiceImpl': Injection of autowired dependencies failed; nested exception is java.lang.IllegalArgumentException: Could not resolve placeholder 'ex-resources.automaton' in value "${ex-resources.automaton}"