### PR TITLE
Fix Liquibase `diff` when JPA entities not modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target/
 # IntelliJ
 /.idea/**
 *.iml
+
+# https://github.com/liquibase/liquibase/issues/2196
+/derby.log

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent-ws</artifactId>
-        <version>17</version>
+        <version>18</version>
         <relativePath/>
     </parent>
 

--- a/src/main/resources/db/changelog/changesets/changelog_20230922T190000Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20230922T190000Z.xml
@@ -3,79 +3,79 @@
     <changeSet author="harperjon" id="1689700000000-1">
         <validCheckSum>8:45941e9fbcb035e0ee19b39e13a44910</validCheckSum>
         <modifyDataType columnName="type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="automata"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-2">
         <validCheckSum>8:4483527312181898d659a2675ea7f701</validCheckSum>
         <modifyDataType columnName="type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="automaton_properties"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-3">
         <validCheckSum>8:67941451371a17c3091bd2efb8692dab</validCheckSum>
         <modifyDataType columnName="operand"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="filters"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-4">
         <validCheckSum>8:e23059d5df5d06edbfa505183066a6d0</validCheckSum>
         <modifyDataType columnName="type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="filters"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-5">
         <validCheckSum>8:098c7268906dbdd7050a8f3120b0543c</validCheckSum>
         <modifyDataType columnName="origin"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="model_parameter_definitions"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-6">
         <validCheckSum>8:79e1d29d87456ccab44fc78849a4410d</validCheckSum>
         <modifyDataType columnName="type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="model_parameter_definitions"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-7">
         <validCheckSum>8:1b6c60118990b9a408dd6eb9084becb3</validCheckSum>
         <modifyDataType columnName="group_type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="model_parameter_sets"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-8">
         <validCheckSum>8:aefaed186963e2da7b9f2d6de441e480</validCheckSum>
         <modifyDataType columnName="group_type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="model_parameters"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-9">
         <validCheckSum>8:4b78efbc6aa67599ef7a4141358627fc</validCheckSum>
         <modifyDataType columnName="type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="model_sets_group"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-10">
         <validCheckSum>8:595c13d8025b1c8b3a6aa45a5cc35674</validCheckSum>
         <modifyDataType columnName="type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="model_variable_definitions"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-11">
         <validCheckSum>8:65a49512617e0bd24fcd2040c9d1b485</validCheckSum>
         <modifyDataType columnName="equipment_type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="models"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-12">
         <validCheckSum>8:c26d4948bb161685649135649249e52b</validCheckSum>
         <modifyDataType columnName="type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="rules"/>
     </changeSet>
     <changeSet author="harperjon" id="1695394758000-13">
         <validCheckSum>8:d641447b3e32fd215f9d8116a168bbaf</validCheckSum>
         <modifyDataType columnName="group_type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="rules"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20231017T182131Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20231017T182131Z.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="chuinetri (base generated)" id="1697566903091-1">
+        <dropPrimaryKey tableName="model_variable_sets_model_variable_definitions"/>
+        <dropPrimaryKey tableName="models_model_parameter_definitions"/>
+        <dropPrimaryKey tableName="models_model_variable_definitions"/>
+    </changeSet>
+    <changeSet author="chuinetri (base generated)" id="1697566903091-2">
+        <addPrimaryKey columnNames="variable_set_name, variable_definition_name" constraintName="model_variable_sets_model_variable_definitionsPK" tableName="model_variable_sets_model_variable_definitions"/>
+        <addPrimaryKey columnNames="model_name, parameter_definition_name" constraintName="models_model_parameter_definitionsPK" tableName="models_model_parameter_definitions"/>
+        <addPrimaryKey columnNames="model_name, variable_definition_name" constraintName="models_model_variable_definitionsPK" tableName="models_model_variable_definitions"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,29 +1,25 @@
 databaseChangeLog:
-
   - include:
       file: changesets/changelog_20211019T140751Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220909T154800Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230503T135347Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230531T113101Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230605T173446Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230515T135427Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230922T190000Z.xml
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20231017T182131Z.xml
       relativeToChangelogFile: true

--- a/src/test/resources/application-default.yml
+++ b/src/test/resources/application-default.yml
@@ -5,7 +5,7 @@ spring:
       dialect: org.hibernate.dialect.H2Dialect
       hibernate.format_sql: true
     hibernate:
-      #to turn off schema validation that fails (because of clob types) and blocks tests even if the the schema is compatible
+      #to turn off schema validation that fails (because of clob types) and blocks tests even if the schema is compatible
       ddl-auto: none
 
 logging:
@@ -18,5 +18,5 @@ logging:
 powsybl-ws:
   database:
     vendor: h2:mem
-    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;DEFAULT_NULL_ORDERING=HIGH
     hostPort: ":"


### PR DESCRIPTION
Liquibase `diff` generate changes when using `main` branch without modifying JPA entities.  
* The diff is from #61 and #65, where the links `@OneToMany` was changed to `@ManyToMany` between
  - `model_variable_sets.variable_set_name` ↔ `model_variable_definitions.variable_definition_name`
  - `models.model_name` ↔ `model_parameter_definitions.parameter_definition_name`
  - `models.model_name` ↔ `model_variable_definitions.variable_definition_name`
* Also add missing compatibility mode in H2 configuration
* ⚠️ need release v18 of powsybl/powsybl-parent/pull/54