### PR TITLE
[GridDyna] Rename automaton equipment type and family

### DIFF
--- a/src/main/java/org/gridsuite/mapping/server/utils/AutomatonFamily.java
+++ b/src/main/java/org/gridsuite/mapping/server/utils/AutomatonFamily.java
@@ -10,6 +10,6 @@ package org.gridsuite.mapping.server.utils;
  * @author Mathieu Scalbert <mathieu.scalbert at rte-france.com>
  */
 public enum AutomatonFamily {
-    CURRENT_LIMIT,
+    CURRENT,
     VOLTAGE,
 }

--- a/src/main/java/org/gridsuite/mapping/server/utils/EquipmentType.java
+++ b/src/main/java/org/gridsuite/mapping/server/utils/EquipmentType.java
@@ -12,7 +12,7 @@ package org.gridsuite.mapping.server.utils;
 public enum EquipmentType {
     GENERATOR,
     LOAD,
-    CURRENT_LIMIT,
+    OVERLOAD_MANAGEMENT,
     VOLTAGE,
     BUS,
     LINE,

--- a/src/test/java/org/gridsuite/mapping/server/MappingControllerTest.java
+++ b/src/test/java/org/gridsuite/mapping/server/MappingControllerTest.java
@@ -122,7 +122,7 @@ public class MappingControllerTest {
                     ],
                     "automata":[
                         {
-                            "family":"CURRENT_LIMIT",
+                            "family":"CURRENT",
                             "model":"OverloadManagementSystem",
                             "setGroup":"automaton_group",
                             "properties":[

--- a/src/test/java/org/gridsuite/mapping/server/ScriptControllerTest.java
+++ b/src/test/java/org/gridsuite/mapping/server/ScriptControllerTest.java
@@ -173,7 +173,7 @@ public class ScriptControllerTest {
                 ],
                 "automata":[
                     {
-                        "family":"CURRENT_LIMIT",
+                        "family":"CURRENT",
                         "model":"OverloadManagementSystem",
                         "setGroup":"automaton_group",
                         "properties":[

--- a/src/test/resources/data/mapping/mapping_01.json
+++ b/src/test/resources/data/mapping/mapping_01.json
@@ -74,7 +74,7 @@
   ],
   "automata": [
     {
-      "family": "CURRENT_LIMIT",
+      "family": "CURRENT",
       "model": "OverloadManagementSystem",
       "setGroup": "CLA_2_4",
       "properties": [
@@ -101,7 +101,7 @@
       ]
     },
     {
-      "family": "CURRENT_LIMIT",
+      "family": "CURRENT",
       "model": "OverloadManagementSystem",
       "setGroup": "CLA_2_5",
       "properties": [

--- a/src/test/resources/mappingIEEE14Test01.json
+++ b/src/test/resources/mappingIEEE14Test01.json
@@ -74,7 +74,7 @@
   ],
   "automata": [
     {
-      "family": "CURRENT_LIMIT",
+      "family": "CURRENT",
       "model": "OverloadManagementSystem",
       "setGroup": "CLA_2_4",
       "properties": [
@@ -101,7 +101,7 @@
       ]
     },
     {
-      "family": "CURRENT_LIMIT",
+      "family": "CURRENT",
       "model": "OverloadManagementSystem",
       "setGroup": "CLA_2_5",
       "properties": [


### PR DESCRIPTION
After migration version dynawo 2.4.0, we want to change the automation equipment type for Current limit automaton and its family

Related PR: https://github.com/gridsuite/griddyna-app/pull/92