### PR TITLE
Rectify implementation of network get values

### DIFF
--- a/src/main/java/org/gridsuite/mapping/server/dto/NetworkValues.java
+++ b/src/main/java/org/gridsuite/mapping/server/dto/NetworkValues.java
@@ -11,7 +11,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.UUID;
 
 /**
  * @author Mathieu Scalbert <mathieu.scalbert at rte-france.com>
@@ -20,6 +19,5 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class NetworkValues {
-    private UUID networkId;
     private List<EquipmentValues> propertyValues;
 }

--- a/src/main/java/org/gridsuite/mapping/server/service/implementation/NetworkServiceImpl.java
+++ b/src/main/java/org/gridsuite/mapping/server/service/implementation/NetworkServiceImpl.java
@@ -110,7 +110,7 @@ public class NetworkServiceImpl implements NetworkService {
         EquipmentValues hdvcLinesEquipmentValues = getHvdcLinesEquipmentValues(network);
         equipmentValuesList.add(hdvcLinesEquipmentValues);
 
-        return new NetworkValues(networkUuid, equipmentValuesList);
+        return new NetworkValues(equipmentValuesList);
     }
 
     private void setPropertyMap(HashMap<String, Set<String>> propertyMap, String value, String propertyName) {

--- a/src/test/java/org/gridsuite/mapping/server/NetworkControllerTest.java
+++ b/src/test/java/org/gridsuite/mapping/server/NetworkControllerTest.java
@@ -52,10 +52,7 @@ import static org.gridsuite.mapping.server.MappingConstants.CASE_API_VERSION;
 import static org.gridsuite.mapping.server.MappingConstants.NETWORK_CONVERSION_API_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -202,7 +199,6 @@ class NetworkControllerTest {
 
         String networkValuesJson = new String(getClass().getResourceAsStream(TEST_DATA_DIR + RESOURCE_PATH_DELIMITER + "network/networkValues.json").readAllBytes());
         NetworkValues networkValues = objectMapper.readValue(networkValuesJson, NetworkValues.class);
-        networkValues.setNetworkId(networkUUID);
 
         String expectNetworkValuesJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(networkValues);
         LOGGER.info("expect network values = " + expectNetworkValuesJson);


### PR DESCRIPTION
## PR Summary
- Remove networkId which is no longer used in griddyna. A mapping now can be associated to a study 
- Clean network import from file, database and situations in dev opf **will be done** in another ticket


